### PR TITLE
Allow setting language for TTS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/*
+epy_reader.egg-info/*

--- a/epy.py
+++ b/epy.py
@@ -195,6 +195,7 @@ class Settings:
     MouseSupport: bool = False
     StartWithDoubleSpread: bool = False
     TTSSpeed: int = 1
+    TTSLang: str = "en-US"
     # -1 is default terminal fg/bg colors
     DarkColorFG: int = 252
     DarkColorBG: int = 235
@@ -2336,7 +2337,7 @@ class Reader:
         try:
             _, path = tempfile.mkstemp(suffix=".wav")
             subprocess.call(
-                ["pico2wave", "-w", path, text],
+                ["pico2wave", f"--lang={self.setting.TTSLang}", "-w", path, text],
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             )


### PR DESCRIPTION
There is now setting option TTSLang, which must set to one language supported by pico2wave.

Fixes #42