### PR TITLE
add speaker support for `gtts-cli - | mpv -`

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ List of supported engines:
 
 - `mimic`
 - `pico2wave`
+- `gtts-mpv` (requires both [gTTS](https://pypi.org/project/gTTS) and [MPV](https://www.mpv.io))
 
 ## Dictionary
 

--- a/src/epy_reader/speakers/__init__.py
+++ b/src/epy_reader/speakers/__init__.py
@@ -2,8 +2,10 @@ __all__ = [
     "SpeakerBaseModel",
     "SpeakerMimic",
     "SpeakerPico",
+    "SpeakerGttsMPV"
 ]
 
 from epy_reader.speakers.base import SpeakerBaseModel
 from epy_reader.speakers.mimic import SpeakerMimic
 from epy_reader.speakers.pico import SpeakerPico
+from epy_reader.speakers.gtts_mpv import SpeakerGttsMPV

--- a/src/epy_reader/speakers/gtts_mpv.py
+++ b/src/epy_reader/speakers/gtts_mpv.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+
+
+import shutil
+import subprocess
+
+from epy_reader.speakers.base import SpeakerBaseModel
+
+
+class SpeakerGttsMPV(SpeakerBaseModel):
+    cmd = "gtts-mpv"
+    available = bool(shutil.which("gtts-cli") and shutil.which("mpv"))
+
+    def speak(self, text: str) -> None:
+        self._gtts_process = subprocess.Popen(
+            ["gtts-cli", "-", *self.args],
+            text=True,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+        )
+        self._mpv_process = subprocess.Popen(
+            ["mpv", "-"],
+            stdin=self._gtts_process.stdout,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        assert self._gtts_process.stdin
+        self._gtts_process.stdin.write(text)
+        self._gtts_process.stdin.close()
+
+    def is_done(self) -> bool:
+        return self._mpv_process.poll() is not None
+
+    def stop(self) -> None:
+        self._gtts_process.terminate()
+        self._mpv_process.terminate()
+
+    def cleanup(self) -> None:
+        pass

--- a/src/epy_reader/utils.py
+++ b/src/epy_reader/utils.py
@@ -10,7 +10,7 @@ from epy_reader.ebooks import URL, Azw, Ebook, Epub, FictionBook, Mobi
 from epy_reader.lib import is_url, tuple_subtract
 from epy_reader.models import Key, LettersCount, NoUpdate, ReadingState, TextStructure, TocEntry
 from epy_reader.parser import parse_html
-from epy_reader.speakers import SpeakerBaseModel, SpeakerMimic, SpeakerPico
+from epy_reader.speakers import SpeakerBaseModel, SpeakerMimic, SpeakerPico, SpeakerGttsMPV
 
 
 def get_ebook_obj(filepath: str) -> Ebook:
@@ -367,7 +367,7 @@ def count_letters_parallel(ebook: Ebook, child_conn) -> None:
 def construct_speaker(
     preferred: Optional[str] = None, args: List[str] = []
 ) -> Optional[SpeakerBaseModel]:
-    available_speakers = [SpeakerMimic, SpeakerPico]
+    available_speakers = [SpeakerMimic, SpeakerPico, SpeakerGttsMPV]
     sorted_speakers = (
         sorted(available_speakers, key=lambda x: int(x.cmd == preferred), reverse=True)
         if preferred


### PR DESCRIPTION
The speech quality of `pico2wave` is pretty bad, and I'm not keen on the heavy dependencies required by `mimic`.

This PR would thus add support for using [gTTS](https://pypi.org/project/gTTS/), a light-weight wrapper around a public Google Translate API, as a speaker. It works in conjunction with [mpv](https://mpv.io/installation/) to actually play sound.