### PR TITLE
Update AUR package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This is just a fork of [epr](https://github.com/wustho/epr) with these extra fea
 - Via AUR
 
   ```shell
-  yay -S epy-git
+  yay -S epy-ereader-git
   ```
 
 - Windows Binary


### PR DESCRIPTION
This PR is to update the readme for an AUR package name change from `epy-git` to `epy-ereader-git`.  This will make the nature of the program clearer to potential users.  The packages will coexist until I submit the AUR package merge request, probably sometime next week.

You may also like to know that I have rebuilt the package with Python 3.11, and it seems to work as expected.