### PR TITLE
Add support for Speech Dispatcher (speechd) and other engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,26 @@ This is just a fork of [epr](https://github.com/wustho/epr) with these extra fea
 
   ```shell
   pip3 install epy-reader
+
+  # or with pipx (better)
+  pipx install epy-reader
   ```
 
 - Via Pip+Git
 
   ```shell
   pip3 install git+https://github.com/wustho/epy
+
+  # or with pipx (better)
+  pipx install git+https://github.com/wustho/epy
+  ```
+
+- Via local+Pipx
+
+  ```shell
+  git clone --depth=1 https://github.com/wustho/epy
+  cd epy/
+  pipx install -e .
   ```
 
 - Via AUR
@@ -138,6 +152,9 @@ To get Text-to-Speech (TTS) support, external TTS engine is necessary.
 
 List of supported engines:
 
+- `speechd` (using spd-say)
+  - [Speech Dispatcher](https://github.com/brailcom/speechd) allow you to easily use other engines system-wide or per application, with default values and custom parameters.
+  - [Piper](https://github.com/rhasspy/piper) is a good neural engine easy to setup with speechd, fast enough even on low-end hardware.
 - `mimic`
 - `pico2wave`
 - `gtts-mpv` (requires both [gTTS](https://pypi.org/project/gTTS) and [MPV](https://www.mpv.io))

--- a/src/epy_reader/speakers/__init__.py
+++ b/src/epy_reader/speakers/__init__.py
@@ -1,11 +1,13 @@
 __all__ = [
     "SpeakerBaseModel",
+    "SpeakerSpeechd",
     "SpeakerMimic",
     "SpeakerPico",
     "SpeakerGttsMPV"
 ]
 
 from epy_reader.speakers.base import SpeakerBaseModel
+from epy_reader.speakers.speechd import SpeakerSpeechd
 from epy_reader.speakers.mimic import SpeakerMimic
 from epy_reader.speakers.pico import SpeakerPico
 from epy_reader.speakers.gtts_mpv import SpeakerGttsMPV

--- a/src/epy_reader/speakers/speechd.py
+++ b/src/epy_reader/speakers/speechd.py
@@ -1,0 +1,31 @@
+import shutil
+import subprocess
+
+from epy_reader.speakers.base import SpeakerBaseModel
+
+
+class SpeakerSpeechd(SpeakerBaseModel):
+    cmd = "spd-say"
+    available = bool(shutil.which("spd-say"))
+
+    def speak(self, text: str) -> None:
+        self.process = subprocess.Popen(
+            [self.cmd, *self.args, "--application-name=epy", "--pipe-mode", "-w" ],
+            text=True,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.STDOUT,
+        )
+        assert self.process.stdin
+        self.process.stdin.write(text)
+        self.process.stdin.close()
+
+    def is_done(self) -> bool:
+        return self.process.poll() is not None
+
+    def stop(self) -> None:
+        self.process.terminate()
+        # self.process.kill()
+
+    def cleanup(self) -> None:
+        pass

--- a/src/epy_reader/speakers/speechd.py
+++ b/src/epy_reader/speakers/speechd.py
@@ -10,7 +10,7 @@ class SpeakerSpeechd(SpeakerBaseModel):
 
     def speak(self, text: str) -> None:
         self.process = subprocess.Popen(
-            [self.cmd, *self.args, "--application-name=epy", "--pipe-mode", "-w" ],
+            [self.cmd, *self.args, "--application-name=epy", "--pipe-mode", "--wait" ],
             text=True,
             stdin=subprocess.PIPE,
             stdout=subprocess.DEVNULL,
@@ -24,6 +24,7 @@ class SpeakerSpeechd(SpeakerBaseModel):
         return self.process.poll() is not None
 
     def stop(self) -> None:
+        subprocess.run([self.cmd, "--cancel", "--application-name=epy"])
         self.process.terminate()
         # self.process.kill()
 

--- a/src/epy_reader/utils.py
+++ b/src/epy_reader/utils.py
@@ -10,7 +10,7 @@ from epy_reader.ebooks import URL, Azw, Ebook, Epub, FictionBook, Mobi
 from epy_reader.lib import is_url, tuple_subtract
 from epy_reader.models import Key, LettersCount, NoUpdate, ReadingState, TextStructure, TocEntry
 from epy_reader.parser import parse_html
-from epy_reader.speakers import SpeakerBaseModel, SpeakerMimic, SpeakerPico, SpeakerGttsMPV
+from epy_reader.speakers import SpeakerBaseModel, SpeakerSpeechd, SpeakerMimic, SpeakerPico, SpeakerGttsMPV
 
 
 def get_ebook_obj(filepath: str) -> Ebook:
@@ -367,7 +367,7 @@ def count_letters_parallel(ebook: Ebook, child_conn) -> None:
 def construct_speaker(
     preferred: Optional[str] = None, args: List[str] = []
 ) -> Optional[SpeakerBaseModel]:
-    available_speakers = [SpeakerMimic, SpeakerPico, SpeakerGttsMPV]
+    available_speakers = [SpeakerSpeechd, SpeakerMimic, SpeakerPico, SpeakerGttsMPV]
     sorted_speakers = (
         sorted(available_speakers, key=lambda x: int(x.cmd == preferred), reverse=True)
         if preferred


### PR DESCRIPTION
TTS support on Linux is growing strong and there is currently many high-quality solutions but most of them are too slow for epy purpose.

I used Mimic3 but it's slow on some devices, Coqui would require even more hardware, so I used Mimic1 for some time.

But, I recently tried [Piper](https://github.com/rhasspy/piper) wich is smooth even on some 15 years old mid-level hardware.

On linux the best way to setup any engine is to use [Speech Dispatcher](https://github.com/brailcom/speechd), it's available in every distro and with a simple module/engine conf file you get defaults and specific settings for every engines (voice, pitch, rate, language...) with the same command lines.

For those interested in Piper, I shared my setup and module configuration in this thread : [Speechd: module request: piper](https://github.com/brailcom/speechd/issues/866)

You can setup `.config/epy/configuration.json` for speechd like that:

``` json
    "PreferredTTSEngine": "speechd",
    "TTSEngineArgs": ["--voice-type=male1", "--language=en", "--rate=10"]
```

An empty `"TTSEngineArgs": []` would use speechd defaults.