### PR TITLE
Dependency Update - PEP 594 - Installs `standard-imghdr` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ epy = "epy_reader.__main__:main"
 [tool.poetry.dependencies]
 python = "^3.8"
 windows-curses = { version = "*", markers = "platform_system == 'Windows'" }
+standard-imghdr = "^3.13.0"
 
 [tool.poetry.dev-dependencies]
 pynvim = "^0.4.3"


### PR DESCRIPTION
As of PEP-594, for Python 3.13 the `imghdr` module has been removed from standard library (deprecated since Python 3.11). cf: https://peps.python.org/pep-0594/#imghdr

EPY program requested this dependency on fresh install on Python 3.13 . This patch install the package by default, regardless of Python version. If already installed in a lower Python version, it will update the package. If the python is >3.13.0, it will install the package.