### PR TITLE
feat: make it configurable to use colors or be terminal neutral

### DIFF
--- a/src/epy_reader/board.py
+++ b/src/epy_reader/board.py
@@ -20,11 +20,13 @@ class InfiniBoard:
     def __init__(
         self,
         screen,
+        settings,
         text: Tuple[str, ...],
         textwidth: int = 80,
         default_style: Tuple[InlineStyle, ...] = tuple(),
         spread: int = 1,
     ):
+        self.settings = settings
         self.screen = screen
         self.screen_rows, self.screen_cols = self.screen.getmaxyx()
         self.textwidth = textwidth
@@ -34,6 +36,13 @@ class InfiniBoard:
         self.default_style: Tuple[InlineStyle, ...] = default_style
         self.temporary_style: Tuple[InlineStyle, ...] = ()
         self.spread = spread
+        # Color initialization is moved to reader.py for a central control.
+        # However, we still need to manage color pairs here based on the setting.
+        # Only define if colors are enabled
+        if curses.has_colors() and not self.settings.NoColors:
+            # These pairs should match those defined in reader.py if you want them to be used
+            curses.init_pair(1, curses.COLOR_WHITE, curses.COLOR_BLACK)  # Default app colors
+            curses.init_pair(2, curses.COLOR_CYAN, curses.COLOR_BLUE)  # Alternate colors
 
         if self.spread == 2:
             self.x = DoubleSpreadPadding.LEFT.value
@@ -50,7 +59,10 @@ class InfiniBoard:
     ) -> None:
         for i in styles:
             if i.row in range(row, row + self.screen_rows - bottom_padding):
-                self.chgat(row, i.row, i.col, i.n_letters, self.screen.getbkgd() | i.attr)
+                # When NoColors is true, use A_NORMAL to respect terminal.
+                # When NoColors is false, use the screen's current background color pair.
+                base_attr = curses.A_NORMAL if self.settings.NoColors else self.screen.getbkgd()
+                self.chgat(row, i.row, i.col, i.n_letters, base_attr | i.attr)
 
             if self.spread == 2 and i.row in range(
                 row + self.screen_rows - bottom_padding,
@@ -61,7 +73,7 @@ class InfiniBoard:
                     i.row - (self.screen_rows - bottom_padding),
                     -self.x + self.x_alt + i.col,
                     i.n_letters,
-                    self.screen.getbkgd() | i.attr,
+                    (curses.A_NORMAL if self.settings.NoColors else self.screen.getbkgd()) | i.attr,
                 )
 
     def getch(self) -> Union[NoUpdate, Key]:
@@ -71,15 +83,28 @@ class InfiniBoard:
         return Key(input)
 
     def getbkgd(self):
-        return self.screen.getbkgd()
+        # Return A_NORMAL for no colors, or the screen's actual background for colors
+        # Now this reflects the actual current background
+        return curses.A_NORMAL if self.settings.NoColors else self.screen.getbkgd()
 
     def chgat(self, row: int, y: int, x: int, n: int, attr: int) -> None:
-        self.screen.chgat(y - row, self.x + x, n, attr)
+        # Ensure the change is within the visible window boundaries
+        if (
+            y - row >= 0
+            and y - row < self.screen_rows
+            and self.x + x >= 0
+            and self.x + x < self.screen_cols
+        ):
+            try:
+                self.screen.chgat(y - row, self.x + x, n, attr)
+            except curses.error:
+                # Catch error if chgat goes out of bounds, especially common with large `n` values
+                # or near window edges. This prevents a crash but might result in incomplete highlighting
+                pass
 
     def write(self, row: int, bottom_padding: int = 0) -> None:
         for n_row in range(min(self.screen_rows - bottom_padding, self.total_lines - row)):
             text_line = self.text[row + n_row]
-
             # NOTE: A bug with python itself: https://bugs.python.org/issue8243
             # It's stated in python docs:
             # > Attempting to write to the lower right corner of a window, subwindow,
@@ -89,7 +114,18 @@ class InfiniBoard:
             # Since the exception is raised "after the character is printed"
             # then it seems to be safe to catch it.
             try:
-                self.screen.addstr(n_row, self.x, text_line)
+                # If colors are enabled, use the currently set background
+                # color pair (color_pair(1) or color_pair(2))
+                # If no specific pair is set, it defaults to color_pair(0)
+                # which is white on black if not use_default_colors()
+                # but since we set color_pair(1) in Reader, we could use that.
+                # Use the default color pair for the app
+                self.screen.addstr(
+                    n_row,
+                    self.x,
+                    text_line,
+                    curses.A_NORMAL if self.settings.NoColors else curses.color_pair(1),
+                )
             except curses.error:
                 pass
 
@@ -98,14 +134,18 @@ class InfiniBoard:
                 and row + self.screen_rows - bottom_padding + n_row < self.total_lines
             ):
                 text_line = self.text[row + self.screen_rows - bottom_padding + n_row]
-                # TODO: clean this up
-                if re.search("\\[IMG:[0-9]+\\]", text_line):
-                    self.screen.addstr(
-                        n_row, self.x_alt, text_line.center(self.textwidth), curses.A_BOLD
+                if re.search(r"\[IMG:[0-9]+\]", text_line):  # Raw string for regex
+                    attr = curses.A_BOLD | (
+                        curses.A_NORMAL if self.settings.NoColors else curses.color_pair(1)
                     )
+                    self.screen.addstr(n_row, self.x_alt, text_line.center(self.textwidth), attr)
                 else:
-                    self.screen.addstr(n_row, self.x_alt, text_line)
-
+                    self.screen.addstr(
+                        n_row,
+                        self.x_alt,
+                        text_line,
+                        curses.A_NORMAL if self.settings.NoColors else curses.color_pair(1),
+                    )
         self.render_styles(row, self.default_style, bottom_padding)
         self.render_styles(row, self.temporary_style, bottom_padding)
         # self.screen.refresh()
@@ -121,14 +161,12 @@ class InfiniBoard:
         for n_row in range(min(self.screen_rows - bottom_padding, self.total_lines - row)):
             text_line = self.text[row + n_row]
             if direction == Direction.FORWARD:
-                # self.screen.addnstr(n_row, self.x + self.textwidth - n, self.text[row+n_row], n)
-                # `+ " " * (self.textwidth - len(self.text[row + n_row]))` is workaround to
-                # to prevent curses trace because not calling screen.clear()
                 self.screen.addnstr(
                     n_row,
                     self.x + self.textwidth - n,
                     text_line + " " * (self.textwidth - len(text_line)),
                     n,
+                    curses.A_NORMAL if self.settings.NoColors else curses.color_pair(1),
                 )
 
                 if (
@@ -141,11 +179,18 @@ class InfiniBoard:
                         self.x_alt + self.textwidth - n,
                         text_line_alt + " " * (self.textwidth - len(text_line_alt)),
                         n,
+                        curses.A_NORMAL if self.settings.NoColors else curses.color_pair(1),
                     )
 
             else:
                 if text_line[self.textwidth - n :]:
-                    self.screen.addnstr(n_row, self.x, text_line[self.textwidth - n :], n)
+                    self.screen.addnstr(
+                        n_row,
+                        self.x,
+                        text_line[self.textwidth - n :],
+                        n,
+                        curses.A_NORMAL if self.settings.NoColors else curses.color_pair(1),
+                    )
 
                 if (
                     self.spread == 2
@@ -157,4 +202,5 @@ class InfiniBoard:
                         self.x_alt,
                         text_line_alt[self.textwidth - n :],
                         n,
+                        curses.A_NORMAL if self.settings.NoColors else curses.color_pair(1),
                     )

--- a/src/epy_reader/config.py
+++ b/src/epy_reader/config.py
@@ -31,7 +31,7 @@ class Config(AppData):
         if sys.platform == "win32":
             setting_dict["PageScrollAnimation"] = False
 
-        self.setting = settings.Settings(**setting_dict)
+        self.settings = settings.Settings(**setting_dict)
         self.keymap = settings.Keymap(**keymap_updated)
         # to build help menu text
         self.keymap_user_dict = keymap_dict

--- a/src/epy_reader/reader.py
+++ b/src/epy_reader/reader.py
@@ -57,12 +57,12 @@ DEBUG = False
 class Reader:
     def __init__(self, screen, ebook: Ebook, config: Config, state: State):
 
-        self.setting = config.setting
+        self.settings = config.settings
         self.keymap = config.keymap
         # to build help menu text
         self.keymap_user_dict = config.keymap_user_dict
 
-        self.seamless = self.setting.SeamlessBetweenChapters
+        self.seamless = self.settings.SeamlessBetweenChapters
 
         # keys that will make
         # windows exit and return the said key
@@ -78,7 +78,7 @@ class Reader:
         self.screen = screen
         self.screen.keypad(True)
         safe_curs_set(0)
-        if self.setting.MouseSupport:
+        if self.settings.MouseSupport:
             curses.mousemask(-1)
         # curses.mouseinterval(0)
         self.screen.clear()
@@ -116,21 +116,21 @@ class Reader:
         self.page_animation: Optional[Direction] = None
 
         # show reading progress
-        self.show_reading_progress: bool = self.setting.ShowProgressIndicator
+        self.show_reading_progress: bool = self.settings.ShowProgressIndicator
         self.reading_progress: Optional[float] = None  # calculate after count_letters()
 
         # search storage
         self.search_data: Optional[SearchData] = None
 
         # double spread
-        self.spread = 2 if self.setting.StartWithDoubleSpread else 1
+        self.spread = 2 if self.settings.StartWithDoubleSpread else 1
 
         # jumps marker container
         self.jump_list: Dict[str, ReadingState] = dict()
 
         # TTS speaker utils
         self._tts_speaker: Optional[SpeakerBaseModel] = construct_speaker(
-            self.setting.PreferredTTSEngine, self.setting.TTSEngineArgs
+            self.settings.PreferredTTSEngine, self.settings.TTSEngineArgs
         )
         self.tts_support: bool = bool(self._tts_speaker)
         self.is_speaking: bool = False
@@ -194,8 +194,8 @@ class Reader:
     def ext_dict_app(self) -> Optional[str]:
         self._ext_dict_app: Optional[str] = None
 
-        if shutil.which(self.setting.DictionaryClient.split()[0]):
-            self._ext_dict_app = self.setting.DictionaryClient
+        if shutil.which(self.settings.DictionaryClient.split()[0]):
+            self._ext_dict_app = self.settings.DictionaryClient
         else:
             for i in settings.DICT_PRESET_LIST:
                 if shutil.which(i) is not None:
@@ -210,8 +210,8 @@ class Reader:
     def image_viewer(self) -> Optional[str]:
         self._image_viewer: Optional[str] = None
 
-        if shutil.which(self.setting.DefaultViewer.split()[0]) is not None:
-            self._image_viewer = self.setting.DefaultViewer
+        if shutil.which(self.settings.DefaultViewer.split()[0]) is not None:
+            self._image_viewer = self.settings.DefaultViewer
         elif sys.platform == "win32":
             self._image_viewer = "start"
         elif sys.platform == "darwin":
@@ -246,7 +246,7 @@ class Reader:
             os.remove(path)
         return k
 
-    def show_loader(self, *, loader_str: str = "\u231B", subtext: Optional[str] = None):
+    def show_loader(self, *, loader_str: str = "\u231b", subtext: Optional[str] = None):
         self.screen.clear()
         rows, cols = self.screen.getmaxyx()
         middle_row = (rows - 1) // 2
@@ -370,8 +370,16 @@ class Reader:
         # pad.refresh(y, 0, 0, x, rows-2, x+width)
         rows, cols = self.screen.getmaxyx()
         stat = curses.newwin(1, cols, rows - 1, 0)
-        if self.is_color_supported:
-            stat.bkgd(self.screen.getbkgd())
+        if self.is_color_supported and not self.settings.NoColors:
+            stat.bkgd(curses.color_pair(1))
+        # Instead, set a default color pair that might be the terminal's default
+        # or just avoid setting `bkgd` on this window, relying on the parent's attributes.
+        # If you need to ensure a contrasting prompt, you might need to
+        # initialize a specific color pair *if* curses.start_color() is called
+        # elsewhere (which we're trying to avoid here for the main reading area).
+        # For this specific prompt, if it's drawing *over* the content,
+        # curses.A_REVERSE on the prompt line usually provides good contrast.
+
         stat.keypad(True)
         curses.echo(True)
         safe_curs_set(2)
@@ -421,9 +429,11 @@ class Reader:
                 stat.addstr(
                     0,
                     len(prompt),
-                    init_text
-                    if len(prompt + init_text) < cols
-                    else "..." + init_text[len(prompt) - cols + 4 :],
+                    (
+                        init_text
+                        if len(prompt + init_text) < cols
+                        else "..." + init_text[len(prompt) - cols + 4 :]
+                    ),
                 )
                 stat.refresh()
         except KeyboardInterrupt:
@@ -443,7 +453,7 @@ class Reader:
         rows, cols = self.screen.getmaxyx()
         # unnecessary
         # if self.spread == 2:
-        #     reading_state = dataclasses.replace(reading_state, textwidth=(cols - 7) // 2)
+        #    reading_state = dataclasses.replace(reading_state, textwidth=(cols - 7) // 2)
 
         x = (cols - reading_state.textwidth) // 2
         if self.spread == 1:
@@ -553,7 +563,7 @@ class Reader:
             if s in self.keymap.Quit:
                 self.search_data = None
                 # for i in found:
-                #     pad.chgat(i[0], i[1], i[2], pad.getbkgd())
+                #    pad.chgat(i[0], i[1], i[2], pad.getbkgd())
                 board.feed_temporary_style()
                 # pad.format()
                 # self.screen.clear()
@@ -610,15 +620,15 @@ class Reader:
             elif s == Key(curses.KEY_RESIZE):
                 return Key(curses.KEY_RESIZE)
 
-            # if reading_state.row + rows - 1 > pad.chunks[pad.find_chunkidx(reading_state.row)]:
-            #     reading_state = dataclasses.replace(
-            #         reading_state, row=pad.chunks[pad.find_chunkidx(reading_state.row)] + 1
-            #     )
+            # if reading_state.row + rows - 1 > board.chunks[board.find_chunkidx(reading_state.row)]:
+            #    reading_state = dataclasses.replace(
+            #        reading_state, row=board.chunks[board.find_chunkidx(reading_state.row)] + 1
+            #    )
 
             while found[sidx][0] not in list(
                 range(reading_state.row, reading_state.row + (rows - 1) * self.spread)
             ):
-                if found[sidx][0] > reading_state.row:
+                if found[sidx][0] > reading_state.row:  # This check is always true TODO
                     reading_state = dataclasses.replace(
                         reading_state, row=reading_state.row + ((rows - 1) * self.spread)
                     )
@@ -630,7 +640,7 @@ class Reader:
                         reading_state = dataclasses.replace(reading_state, row=0)
 
             # formats = [InlineStyle(row=i[0], col=i[1], n_letters=i[2], attr=curses.A_REVERSE) for i in found]
-            # pad.feed_style(formats)
+            # board.feed_style(formats)
             styles: List[InlineStyle] = []
             for n, i in enumerate(found):
                 attr = curses.A_REVERSE if n == sidx else curses.A_NORMAL
@@ -640,7 +650,7 @@ class Reader:
                 )
             board.feed_temporary_style(tuple(styles))
 
-            self.screen.clear()
+            self.screen.clear()  # Clears the whole screen
             self.screen.addstr(rows - 1, 0, msg, curses.A_REVERSE)
             self.screen.refresh()
             # pad.refresh(reading_state.row, 0, 0, x, rows - 2, x + reading_state.textwidth)
@@ -860,6 +870,7 @@ class Reader:
 
         board = InfiniBoard(
             screen=self.screen,
+            settings=self.settings,
             text=text_structure.text_lines,
             textwidth=reading_state.textwidth,
             default_style=text_structure.formatting,
@@ -924,7 +935,7 @@ class Reader:
                             and reading_state.content_index == len(contents) - 1
                         ):
                             self.is_speaking = False
-                        continue
+                            continue
 
                     elif k in self.keymap.DoubleSpreadToggle:
                         if cols < mincols_doublespr:
@@ -1026,9 +1037,9 @@ class Reader:
                             )
 
                     # elif k in K["HalfScreenUp"] | K["HalfScreenDown"]:
-                    #     countstring = str(rows // 2)
-                    #     k = list(K["ScrollUp" if k in K["HalfScreenUp"] else "ScrollDown"])[0]
-                    #     continue
+                    #    countstring = str(rows // 2)
+                    #    k = list(K["ScrollUp" if k in K["HalfScreenUp"] else "ScrollDown"])[0]
+                    #    continue
 
                     elif k in self.keymap.NextChapter:
                         ntoc = find_current_content_index(
@@ -1295,9 +1306,9 @@ class Reader:
                                     else:
                                         current_content_index = reading_state.content_index
                                         # for n, content in enumerate(self.ebook.contents):
-                                        #     content_path = content
-                                        #     if reading_state.row < sum(totlines_per_content[:n]):
-                                        #         break
+                                        #    content_path = content
+                                        #    if reading_state.row < sum(totlines_per_content[:n]):
+                                        #       break
 
                                     content_path = self.ebook.contents[current_content_index]
                                     assert isinstance(content_path, str)
@@ -1310,24 +1321,25 @@ class Reader:
                                 if DEBUG:
                                     raise e
 
-                    elif (
-                        k in self.keymap.SwitchColor
-                        and self.is_color_supported
-                        and countstring in {"", "0", "1", "2"}
-                    ):
-                        if countstring == "":
-                            count_color = curses.pair_number(self.screen.getbkgd())
-                            if count_color not in {2, 3}:
-                                count_color = 1
-                            count_color = count_color % 3
-                        else:
-                            count_color = count
-                        self.screen.bkgd(curses.color_pair(count_color + 1))
-                        # pad.format()
+                    elif k in self.keymap.SwitchColor and self.is_color_supported:
+                        if not self.settings.NoColors:
+                            current_pair = curses.pair_number(self.screen.getbkgd())
+                            # Cycle between pair 1 and 2
+                            next_pair_index = (current_pair % 2) + 1
+                            self.screen.bkgd(curses.color_pair(next_pair_index))
+                            # Update board's internal screen
+                            # background if it's needed for its own calculations
+                            # Not directly needed if board uses A_NORMAL
+                            # board.screen.bkgd(curses.color_pair(next_pair_index))
+
+                        # Invalidate previous text to force redraw with new colors
+                        # This is implicit by returning
+                        # ReadingState, which triggers a full redraw.
                         return ReadingState(
                             content_index=reading_state.content_index,
                             textwidth=reading_state.textwidth,
                             row=reading_state.row,
+                            rel_pctg=reading_state.row / totlines,  # Preserve progress
                         )
 
                     elif k in self.keymap.AddBookmark:
@@ -1415,9 +1427,11 @@ class Reader:
                             return dataclasses.replace(
                                 marked_reading_state,
                                 textwidth=reading_state.textwidth,
-                                rel_pctg=None
-                                if marked_reading_state.textwidth == reading_state.textwidth
-                                else marked_reading_state.rel_pctg,
+                                rel_pctg=(
+                                    None
+                                    if marked_reading_state.textwidth == reading_state.textwidth
+                                    else marked_reading_state.rel_pctg
+                                ),
                                 section="",
                             )
                         else:
@@ -1480,6 +1494,7 @@ class Reader:
                                 content_index=reading_state.content_index,
                                 textwidth=reading_state.textwidth,
                                 row=reading_state.row,
+                                rel_pctg=reading_state.row / totlines,
                             )
 
                     countstring = ""
@@ -1497,7 +1512,7 @@ class Reader:
                     )
 
                 try:
-                    if self.setting.PageScrollAnimation and self.page_animation:
+                    if self.settings.PageScrollAnimation and self.page_animation:
                         self.screen.clear()
                         for i in range(1, reading_state.textwidth + 1):
                             curses.napms(1)
@@ -1556,7 +1571,7 @@ class Reader:
                     elif mouse_event[4] == curses.BUTTON2_CLICKED:
                         k = self.keymap.TTSToggle[0]
 
-                if checkpoint_row:
+                if checkpoint_row is not None:
                     board.feed_temporary_style()
                     checkpoint_row = None
 

--- a/src/epy_reader/settings.py
+++ b/src/epy_reader/settings.py
@@ -40,6 +40,7 @@ class Settings:
     PageScrollAnimation: bool = True
     MouseSupport: bool = False
     StartWithDoubleSpread: bool = False
+    NoColors: int = False
     # -1 is default terminal fg/bg colors
     DefaultColorFG: int = -1
     DefaultColorBG: int = -1

--- a/src/epy_reader/speakers/__init__.py
+++ b/src/epy_reader/speakers/__init__.py
@@ -1,9 +1,4 @@
-__all__ = [
-    "SpeakerBaseModel",
-    "SpeakerMimic",
-    "SpeakerPico",
-    "SpeakerGttsMPV"
-]
+__all__ = ["SpeakerBaseModel", "SpeakerMimic", "SpeakerPico", "SpeakerGttsMPV"]
 
 from epy_reader.speakers.base import SpeakerBaseModel
 from epy_reader.speakers.mimic import SpeakerMimic

--- a/src/epy_reader/utils.py
+++ b/src/epy_reader/utils.py
@@ -337,10 +337,12 @@ def construct_relative_reading_state(
         content_index=index,
         textwidth=abs_reading_state.textwidth,
         row=abs_reading_state.row - cumulative_contents_lines + content_lines,
-        rel_pctg=abs_reading_state.rel_pctg
-        - ((cumulative_contents_lines - content_lines) / all_contents_lines)
-        if abs_reading_state.rel_pctg
-        else None,
+        rel_pctg=(
+            abs_reading_state.rel_pctg
+            - ((cumulative_contents_lines - content_lines) / all_contents_lines)
+            if abs_reading_state.rel_pctg
+            else None
+        ),
         section=abs_reading_state.section,
     )
 


### PR DESCRIPTION
There is new configuration option NoColors, which when it is set in ~/.config/epy/configuration.json, make epy not set any colours, but be transparent to the terminal.