### PR TITLE
Fix Library crash with CJK characters in book titles

### DIFF
--- a/src/epy_reader/utils.py
+++ b/src/epy_reader/utils.py
@@ -36,6 +36,30 @@ def safe_curs_set(state: int) -> None:
         return
 
 
+def display_width(s: str) -> int:
+    """Calculate the display width of a string (CJK chars take 2 columns)."""
+    width = 0
+    for ch in s:
+        if ord(ch) > 127:
+            width += 2
+        else:
+            width += 1
+    return width
+
+
+def truncate_by_width(s: str, max_width: int) -> str:
+    """Truncate a string to fit within max display width."""
+    result = []
+    width = 0
+    for ch in s:
+        ch_width = 2 if ord(ch) > 127 else 1
+        if width + ch_width > max_width:
+            break
+        result.append(ch)
+        width += ch_width
+    return "".join(result)
+
+
 def find_current_content_index(
     toc_entries: Tuple[TocEntry, ...], toc_secid: Mapping[str, int], index: int, y: int
 ) -> int:
@@ -122,7 +146,7 @@ def choice_win(allowdel=False):
                 # remove newline from choice entries
                 # mostly happens in FictionBook (.fb2) format
                 strs = "  " + i.replace("\n", " ")
-                strs = strs[0 : wi - 3]
+                strs = truncate_by_width(strs, wi - 3)
                 pad.addstr(n, 0, strs)
                 span.append(len(strs))
 


### PR DESCRIPTION
CJK characters (Chinese, Japanese, Korean) occupy 2 terminal columns, but the code truncated strings by character count instead of display width. This caused pad.addstr() to overflow and crash when displaying Library items with CJK characters in titles.

Added display_width() and truncate_by_width() functions to properly handle character width when truncating strings for display.